### PR TITLE
fixed TZ issue with recurring_ical_events

### DIFF
--- a/inkycal/modules/ical_parser.py
+++ b/inkycal/modules/ical_parser.py
@@ -114,11 +114,10 @@ class iCalendar:
 
     # Recurring events time-span has to be in this format:
     # "%Y%m%dT%H%M%SZ" (python strftime)
-    fmt = lambda date: (date.year, date.month, date.day, date.hour,
-                        date.minute, date.second)
+    fmt = 'YYYYMMDD[T]HHmmss[Z]'
 
-    t_start_recurring = fmt(t_start)
-    t_end_recurring = fmt(t_end)
+    t_start_recurring = t_start.to('UTC').format(fmt)
+    t_end_recurring = t_end.to('UTC').format(fmt)
 
     # Fetch recurring events
     recurring_events = (recurring_ical_events.of(ical).between(


### PR DESCRIPTION
Because recurring_ical_events can have no TZ associated with it, the date/time we send it must be in UTC. I fixed the t_recurring variables so they are converted to UTC (they were previously in local time), and made sure they were still in the correct format.